### PR TITLE
Add Elixir 1.2.1

### DIFF
--- a/dockerfiles/elixir-dev/1.2.1/Dockerfile
+++ b/dockerfiles/elixir-dev/1.2.1/Dockerfile
@@ -1,0 +1,11 @@
+FROM msaraiva/elixir:1.2.1
+MAINTAINER Marlus Saraiva <marlus.saraiva@gmail.com>
+
+RUN apk --update add erlang-crypto erlang-syntax-tools erlang-parsetools erlang-inets erlang-ssl erlang-public-key erlang-eunit \
+    erlang-asn1 erlang-sasl erlang-erl-interface erlang-dev wget git && \
+    rm -rf /var/cache/apk/*
+
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+CMD ["/bin/sh"]

--- a/dockerfiles/elixir-dev/1.2.1/README.md
+++ b/dockerfiles/elixir-dev/1.2.1/README.md
@@ -1,0 +1,51 @@
+Elixir on Alpine Linux + basic development tools
+=====
+
+Elixir is a dynamic, functional language designed for building scalable and maintainable applications.
+
+Image size: **52.11 MB**
+
+See [Erlang/Elixir on Alpine Linux](https://github.com/msaraiva/alpine-erlang) to learn more about creating **minimal Erlang/Elixir docker images with Alpine Linux**.
+
+> **Notice:** If you don't need to download and compile dependencies (i.e. just using iex or similar), you can use [msaraiva/elixir](https://registry.hub.docker.com/u/msaraiva/elixir/) which is much smaller.
+
+The following packages are pre-installed:
+
+- erlang + dependencies
+- erlang-inets
+- erlang-ssl
+- erlang-public-key
+- erlang-crypto
+- erlang-syntax-tools
+- erlang-parsetools
+- erlang-asn1
+- erlang-sasl
+- erlang-erl-interface
+- erlang-dev
+- erlang-eunit
+- elixir
+- wget
+- git + dependencies
+- rebar
+- hex
+
+> **Notice:** In order to keep images as compact as possible, Erlang libraries for Alpine Linux are split into many different packages. The full list of Erlang packages available can be found [here](https://pkgs.alpinelinux.org/packages?name=erlang%25&repo=all&arch=x86_64&maintainer=all).
+
+## Usage
+
+```
+FROM msaraiva/elixir-dev
+
+RUN apk --update add bash vim git-bash-completion && \
+    rm -rf /var/cache/apk/*
+
+RUN git clone https://github.com/elixir-lang/vim-elixir.git ~/.vim
+
+RUN curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh -o ~/.git-prompt.sh
+
+ADD prompt.sh /etc/profile.d/prompt.sh
+ADD aliases.sh /etc/profile.d/aliases.sh
+ADD gitconfig /root/.gitconfig
+
+CMD ["/bin/bash", "-l"]
+```

--- a/dockerfiles/elixir-gcc/1.2.1/Dockerfile
+++ b/dockerfiles/elixir-gcc/1.2.1/Dockerfile
@@ -1,0 +1,5 @@
+FROM msaraiva/elixir-dev:1.2.1
+
+RUN apk --update add gcc make libc-dev libgcc && rm -rf /var/cache/apk/*
+
+CMD ["/bin/sh"]

--- a/dockerfiles/elixir-gcc/1.2.1/README.md
+++ b/dockerfiles/elixir-gcc/1.2.1/README.md
@@ -1,0 +1,28 @@
+Elixir on Alpine Linux + GCC
+=====
+
+Elixir minimal environment for compiling Elixir applications with NIFs.
+
+Image size: **141.8 MB**
+
+See [Erlang/Elixir on Alpine Linux](https://github.com/msaraiva/alpine-erlang) to learn more about creating **minimal Erlang/Elixir docker images with Alpine Linux**.
+
+The following packages are pre-installed:
+
+- All packages from [msaraiva/elixir-dev](https://registry.hub.docker.com/u/msaraiva/elixir-dev/)
+- binutils-libs
+- binutils
+- libgomp
+- pkgconf
+- pkgconfig
+- gmp5
+- mpfr3
+- mpc1
+- gcc
+- make
+- musl-dbg
+- musl-dev
+- linux-headers
+- libc-dev
+- libgcc
+

--- a/dockerfiles/elixir/1.2.1/Dockerfile
+++ b/dockerfiles/elixir/1.2.1/Dockerfile
@@ -1,0 +1,17 @@
+FROM msaraiva/erlang:18.1
+MAINTAINER Marlus Saraiva <marlus.saraiva@gmail.com>
+
+ENV ELIXIR_VERSION 1.2.1
+
+RUN apk --update add --virtual build-dependencies wget ca-certificates && \
+    wget https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/Precompiled.zip && \
+    mkdir -p /opt/elixir-${ELIXIR_VERSION}/ && \
+    unzip Precompiled.zip -d /opt/elixir-${ELIXIR_VERSION}/ && \
+    rm Precompiled.zip && \
+    apk del build-dependencies && \
+    rm -rf /etc/ssl && \
+    rm -rf /var/cache/apk/*
+
+ENV PATH $PATH:/opt/elixir-${ELIXIR_VERSION}/bin
+
+CMD ["/bin/sh"]

--- a/dockerfiles/elixir/1.2.1/README.md
+++ b/dockerfiles/elixir/1.2.1/README.md
@@ -1,0 +1,30 @@
+Elixir on Alpine Linux
+=====
+
+Elixir is a dynamic, functional language designed for building scalable and maintainable applications.
+
+Image size: **23.24 MB**
+
+See [Erlang/Elixir on Alpine Linux](https://github.com/msaraiva/alpine-erlang) to learn more about creating **minimal Erlang/Elixir docker images with Alpine Linux**.
+
+> **Notice:** This image does not contain git, wget, rebar or hex. If you need to download dependencies, see [msaraiva/elixir-dev](https://registry.hub.docker.com/u/msaraiva/elixir-dev/)
+
+The following packages are pre-installed:
+
+- erlang + dependencies
+- elixir
+
+> **Notice:** In order to keep images as compact as possible, Erlang libraries for Alpine Linux are split into many different packages. The full list of Erlang packages available can be found [here](https://pkgs.alpinelinux.org/packages?name=erlang%25&repo=all&arch=x86_64&maintainer=all)
+
+## Usage
+
+```
+$ docker run --rm -it msaraiva/elixir iex
+Erlang/OTP 18 [erts-7.1] [source] [64-bit] [async-threads:10] [kernel-poll:false]
+
+Interactive Elixir (1.2.1) - press Ctrl+C to exit (type h() ENTER for help)
+iex(1)> IO.puts "Hello there!"
+Hello there!
+:ok
+iex(2)>
+```


### PR DESCRIPTION
Hey,

I took the liberty to add Elixir 1.2.1.

It would be cool to get the latest Erlang version soon, too. Looks like the Alpine package already has 18.2.2.

Cheers
